### PR TITLE
Making FDTool Python 3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ candidate keys from datasets read in from .csv, .txt, and .pkl files.
 
 ##### Dependencies:
 
-  1. [Python2](https://www.python.org/) (version 2.7.8 or later recommended)
+  1. [Python3](https://www.python.org/)
 
   2. [Pandas](https://pandas.pydata.org/); pip install pandas
 

--- a/fdtool/__main__.py
+++ b/fdtool/__main__.py
@@ -1,20 +1,20 @@
-"""fdtool.__main__: executed when fdtool directory is called as script."""
-import multiprocessing, time, sys
-from fdtool import main
-from config import MAX_TIME
-
-
-# Start main as a process
-p = multiprocessing.Process(target=main, name="Main")
-p.start()
-# Wait for main
-p.join(MAX_TIME)
-
-# If thread is active
-if p.is_alive():
-    # Print exceeded time limit
-    print "\n", "Exceeded preset time limit."; sys.stdout.flush()
-    # Terminate main
-    p.terminate()
-    # Cleanup
-    p.join()
+"""fdtool.__main__: executed when fdtool directory is called as script."""
+import multiprocessing, time, sys
+from .fdtool import main
+from .config import MAX_TIME
+
+
+# Start main as a process
+p = multiprocessing.Process(target=main, name="Main")
+p.start()
+# Wait for main
+p.join(MAX_TIME)
+
+# If thread is active
+if p.is_alive():
+    # Print exceeded time limit
+    print("\n", "Exceeded preset time limit."); sys.stdout.flush()
+    # Terminate main
+    p.terminate()
+    # Cleanup
+    p.join()

--- a/fdtool/fdtool.py
+++ b/fdtool/fdtool.py
@@ -230,85 +230,92 @@ def main():
 
     while True:
 
-        
-
-        # Increment k; initialize C_km1
-
-        k += 1; C_km1 = C[k-1];
-
-        # Initialize Closure at next next k-level; update dict accordinaly
-
-        Closure_k = {binaryRepr.toBin(Subset, U) : set(Subset) for Subset in next(Subset_Gen)}; Closure.update(Closure_k);
-
-        # Update Cardinality dict with next k-level
-
-        Cardinality.update({element: None for element in Closure_k})
-
-
-
-        if k > 1:
-
-            # Dereference Closure and Cardinality at (k-2)-level
-
-            for Subset in C[k-2]: del Closure[binaryRepr.toBin(Subset, U)], Cardinality[binaryRepr.toBin(Subset, U)];
-
-            # Dereference (k-2)-level
-
-            C[k-2] = None;
-
-
-
-        # Run Apriori_Gen to get k-level Candidate row from (k-1)-level Candidate row
-
-        C_k = Apriori_Gen.oneUp(C_km1)
-
-        # Run GetFDs to get closure and set of functional dependencies
-
-        Closure, F, Cardinality = GetFDs.f(C_km1, df, Closure, U, Cardinality)
-
-        # Run Obtain Equivalences to get set of attribute equivalences
-
-        E = ObtainEquivalences.f(C_km1, F, Closure, U)
-
-        # Run Prune to reduce next k-level iterateion and delete equivalences; initialize C_k
-
-        C_k, Closure, df = Prune.f(C_k, E, Closure, df, U); C[k] = C_k;
-
-        #Increment counter for the number of Equivalences/FDs added at this level
-
-        Counter[0] += len(E); Counter[1] += len(F); E_Set += E
+        try:
 
         
 
-        # Print out FDs
+            # Increment k; initialize C_km1
 
-        for FunctionalDependency in F:
+            k += 1; C_km1 = C[k-1];
 
-            # Store well-formatted FDs in empty list
+            # Initialize Closure at next next k-level; update dict accordinaly
 
-            FD_Store.append(["".join(sorted([Alpha_Dict[i] for i in FunctionalDependency[0]])), Alpha_Dict[FunctionalDependency[1]]]);
+            Closure_k = {binaryRepr.toBin(Subset, U) : set(Subset) for Subset in next(Subset_Gen)}; 
+            Closure.update(Closure_k);
 
-            # Create string for functional dependency
+            # Update Cardinality dict with next k-level
 
-            String = "{" + ", ".join(FunctionalDependency[0]) + "} -> {" + str(FunctionalDependency[1]) + "}"
+            Cardinality.update({element: None for element in Closure_k})
 
-            # Print FD String
 
-            print(String); sys.stdout.flush();
 
-            # Write string to TXT file
+            if k > 1:
 
-            file.write(String + "\n")
+                # Dereference Closure and Cardinality at (k-2)-level
 
-        
+                for Subset in C[k-2]: del Closure[binaryRepr.toBin(Subset, U)], Cardinality[binaryRepr.toBin(Subset, U)];
 
-        # Break while loop if cardinality of C_k is 0
+                # Dereference (k-2)-level
 
-        if not len(C_k) > 0: break;
+                C[k-2] = None;
 
-        # Break while loop if k-level reaches level set in config
 
-        if k is not None and MAX_K_LEVEL ==k: break;
+
+            # Run Apriori_Gen to get k-level Candidate row from (k-1)-level Candidate row
+
+            C_k = Apriori_Gen.oneUp(C_km1)
+
+            # Run GetFDs to get closure and set of functional dependencies
+
+            Closure, F, Cardinality = GetFDs.f(C_km1, df, Closure, U, Cardinality)
+
+            # Run Obtain Equivalences to get set of attribute equivalences
+
+            E = ObtainEquivalences.f(C_km1, F, Closure, U)
+
+            # Run Prune to reduce next k-level iterateion and delete equivalences; initialize C_k
+
+            C_k, Closure, df = Prune.f(C_k, E, Closure, df, U); C[k] = C_k;
+
+            #Increment counter for the number of Equivalences/FDs added at this level
+
+            Counter[0] += len(E); Counter[1] += len(F); E_Set += E
+
+            
+
+            # Print out FDs
+
+            for FunctionalDependency in F:
+
+                # Store well-formatted FDs in empty list
+
+                FD_Store.append(["".join(sorted([Alpha_Dict[i] for i in FunctionalDependency[0]])), Alpha_Dict[FunctionalDependency[1]]]);
+
+                # Create string for functional dependency
+
+                String = "{" + ", ".join(FunctionalDependency[0]) + "} -> {" + str(FunctionalDependency[1]) + "}"
+
+                # Print FD String
+
+                print(String); sys.stdout.flush();
+
+                # Write string to TXT file
+
+                file.write(String + "\n")
+
+            
+
+            # Break while loop if cardinality of C_k is 0
+
+            if not len(C_k) > 0: break;
+
+            # Break while loop if k-level reaches level set in config
+
+            if k is not None and MAX_K_LEVEL ==k: break;
+
+        except StopIteration:
+            break
+
 
 
 
@@ -387,8 +394,3 @@ def main():
     # Close file
 
     file.close()
-
-
-
-
-

--- a/fdtool/fdtool.py
+++ b/fdtool/fdtool.py
@@ -1,196 +1,394 @@
 # FD Mine(r(U))
+
 # Input: A relation r(U) over U = {v_1, ... ,v_m}
+
 # Output: A set F of functional dependences over r(U)
+
 # F = Null_Set
+
 # E = Null_Set
+
 # C_1 = U
+
 # k = 1
+
 #
+
 # C_k = CalculatePartition(C_k, r(U))
+
 # C_k = InitialClosure(C_k)
+
 # while Cardinality(C_k) > 0:
+
 #{
+
 #   k += 1
+
 #   C_k = Apriori_Gen(C_km1)
+
 #   C_k = CalculatePartition(C_k, r(U))
+
 #   C_k = InitialClosure(C_k)
+
 #   F = F *Union* ObtainFDs(C_km1)
+
 #   E = E *Union* ObtainEquivalences(C_km1, F)
+
 #   C_k = Prune(C_km1, C_k, E)
+
 #}
+
+
 
 __version__="0.1.7"
 
 
+
+
+
 import pandas as pd
+
 import sys, time, argparse, ntpath, pickle, csv
-from modules import *
-from string import ascii_lowercase
-from config import MAX_K_LEVEL
+
+from .modules import *
+
+from string import ascii_letters, ascii_uppercase
+
+from .config import MAX_K_LEVEL
+
+
 
 def main():
 
+
+
     # Define filePath
+
     filePath = sys.argv[1]
 
+    letters = ascii_uppercase + u"ÄÖÜÇÁÉÍÓÚÀÈÌÒÙÃẼĨÕŨÂÊÎÔÛËÏ"
+
+
+
     # Print reading file
-    print "\n" + "Reading file: \n" + str(filePath) + "\n"; sys.stdout.flush();
+
+    print("\n" + "Reading file: \n" + str(filePath) + "\n"); sys.stdout.flush();
+
     # Define file extension from path
+
     fileExtension = ntpath.basename(filePath).split('.')[-1]
 
+
+
     if not fileExtension == "pkl":
+
         # Read in file, determine whether a pkl or txt/csv
+
         try:
+
             
+
             # Detect delimiter
+
             sniffer = csv.Sniffer()
+
             sniffer.preferred=[',','|',';',':','~']            
-            csvFile=open(filePath, 'rb')
-            for row in csv.reader(csvFile,delimiter="\t"):
+
+            csvFile=open(filePath, 'r', encoding='utf-8')
+
+            for row in csv.reader(csvFile, delimiter="\t"):
+
                 row1=row
+
                 break;
+
             csvFile.close()
+
             dialect=sniffer.sniff(str(row1))
+
             sepType = dialect.delimiter
 
+
+
             if sepType not in {",", "|", ";", ":", "~"}:
-                print "Invalid delimiter"
+
+                print("Invalid delimiter")
+
                 sys.stdout.flush()
+
                 return;
 
+
+
             # Read in pandas data frame from csv file
-            df = pd.read_csv(filePath, sep = sepType);
-        except pd.parser.CParserError:
-            print "Invalid file"
+
+            df = pd.read_csv(filePath, sep = ";");
+
+        except pd.errors.ParserError:
+
+            print("Invalid file")
+
             sys.stdout.flush()
+
             return;
+
         except IOError:
-            print "File not found"
+
+            print("File not found")
+
             sys.stdout.flush()
+
             return;
+
     else:
+
         try:
+
             # Read in pandas data fram pkl file
+
             df = pd.read_pickle(filePath);
+
         except IOError:
-            print "File not found"
+
+            print("File not found")
+
             sys.stdout.flush()
+
             return;
+
+
 
     # Define start time
+
     start_time = time.time()
+
     
+
     # Create default name for outFile if one is not chosen on command
+
     if len(sys.argv) > 2: file  = open(sys.argv[2], 'w+')
+
     else: file = open(str(ntpath.basename(filePath)).split('.')[0] + '.FD_Info.txt', 'w+')
+
     
+
     # Add name of file , row count, columns to info string
+
     file.write(str("Table : " + str(ntpath.basename(filePath)).split('.')[0] + "\n" + "Columns : " 
+
         + str(", ".join(list(df.head(0)))) + "\n\n" + "Functional Dependencies: \n"))
 
+
+
     # Print line
+
     print("Functional Dependencies: "); sys.stdout.flush();
+
     # Define header; Initialize k; 
+
     U = list(df.head(0)); k = 0;
+
     
+
     try:
+
         # Create dictionary to convert column names into alphabetical characters
-        Alpha_Dict = {U[i]: ascii_lowercase.upper()[i] for i in range(len(U))}
+
+        Alpha_Dict = {U[i]: letters[i] for i in list(range(len(U)))}
+
     except IndexError:
-        print "Table exceeds max column count"
+
+        print("Table exceeds max column count")
+
         sys.stdout.flush()
+
         return;
+
     
+
     # Initialize lattice with singleton sets at 1-level
+
     C = [[[item] for item in U]] + [None for level in range(len(U) - 1)]
+
     # Create Generator to find next k-level attribute subsets
+
     Subset_Gen = ([x for x in Apriori_Gen.powerset(U) if len(x) == k] for k in range(1, len(max(Apriori_Gen.powerset(U), key=len))+1))
+
     # Initialize Closure as Python dict
+
     Closure = {binaryRepr.toBin(Subset, U) : set(Subset) for Subset in next(Subset_Gen)}
+
     # Initialize Cardinality as Python dict
+
     Cardinality = {element : None for element in Closure}
+
     # Create counter for number of Equivalences and FDs; initialize list to store FDs; list to store equivalences;
+
     Counter=[0,0]; FD_Store = []; E_Set = [];
 
+
+
     while True:
+
         
+
         # Increment k; initialize C_km1
+
         k += 1; C_km1 = C[k-1];
+
         # Initialize Closure at next next k-level; update dict accordinaly
+
         Closure_k = {binaryRepr.toBin(Subset, U) : set(Subset) for Subset in next(Subset_Gen)}; Closure.update(Closure_k);
+
         # Update Cardinality dict with next k-level
+
         Cardinality.update({element: None for element in Closure_k})
 
+
+
         if k > 1:
+
             # Dereference Closure and Cardinality at (k-2)-level
+
             for Subset in C[k-2]: del Closure[binaryRepr.toBin(Subset, U)], Cardinality[binaryRepr.toBin(Subset, U)];
+
             # Dereference (k-2)-level
+
             C[k-2] = None;
 
+
+
         # Run Apriori_Gen to get k-level Candidate row from (k-1)-level Candidate row
+
         C_k = Apriori_Gen.oneUp(C_km1)
+
         # Run GetFDs to get closure and set of functional dependencies
+
         Closure, F, Cardinality = GetFDs.f(C_km1, df, Closure, U, Cardinality)
+
         # Run Obtain Equivalences to get set of attribute equivalences
+
         E = ObtainEquivalences.f(C_km1, F, Closure, U)
+
         # Run Prune to reduce next k-level iterateion and delete equivalences; initialize C_k
+
         C_k, Closure, df = Prune.f(C_k, E, Closure, df, U); C[k] = C_k;
+
         #Increment counter for the number of Equivalences/FDs added at this level
+
         Counter[0] += len(E); Counter[1] += len(F); E_Set += E
+
         
+
         # Print out FDs
+
         for FunctionalDependency in F:
+
             # Store well-formatted FDs in empty list
+
             FD_Store.append(["".join(sorted([Alpha_Dict[i] for i in FunctionalDependency[0]])), Alpha_Dict[FunctionalDependency[1]]]);
+
             # Create string for functional dependency
+
             String = "{" + ", ".join(FunctionalDependency[0]) + "} -> {" + str(FunctionalDependency[1]) + "}"
+
             # Print FD String
+
             print(String); sys.stdout.flush();
+
             # Write string to TXT file
+
             file.write(String + "\n")
+
         
+
         # Break while loop if cardinality of C_k is 0
+
         if not len(C_k) > 0: break;
+
         # Break while loop if k-level reaches level set in config
+
         if k is not None and MAX_K_LEVEL ==k: break;
 
+
+
     # Print equivalences
+
     file.write("\n" + "Equivalences: " + "\n")
-    print "\n" + "Equivalences: "; sys.stdout.flush();
+
+    print("\n" + "Equivalences: "); sys.stdout.flush();
+
     # Iterate through equivalences returned
+
     for Equivalence in E_Set:
+
         # Create string for functional dependency
+
         String = "{" + ", ".join(Equivalence[0]) + "} <-> {" + ", ".join(Equivalence[1]) + "}"
+
         # Print equivalence string
+
         print(String); sys.stdout.flush();
+
         # Write string to TXT file
+
         file.write(String + "\n")
 
+
+
     # Print out keys 
+
     file.write("\n" + "Keys: " + "\n")
-    print "\n" + "Keys: "; sys.stdout.flush();
+
+    print("\n" + "Keys: "); sys.stdout.flush();
+
     # Get string of column names sorted to alphabetical characters
+
     SortedAlphaString = "".join(sorted([Alpha_Dict[item] for item in Alpha_Dict]))
+
     # Run required inputs through keyList module to determine keys with
+
     keyList = keyRun.f(U, SortedAlphaString, FD_Store);
+
     # Iterate through keys returned
+
     for key in keyList:
+
         # Write keys to file
+
         file.write(str(key) + "\n")
+
         # Print keys
-        print str(key); sys.stdout.flush();
+
+        print(str(key)); sys.stdout.flush();
+
     
+
     # Create string to give user info of script
+
     checkInfoString = str("\n" + "Time (s): " + str(round(time.time() - start_time, 4)) + "\n"
+
             + "Row count: " + str(df.count()[0]) + "\n" + "Attribute count: " + str(len(U)) + "\n"
+
             + "Number of Equivalences: " + str(Counter[0]) + "\n" + "Number of FDs: " + str(Counter[1]) + "\n"
+
             "Number of FDs checked: " + str(GetFDs.CardOfPartition.calls))
+
     
+
     # Write info at bottom
+
     file.write(checkInfoString)
+
     #Print elapsed time
+
     print(checkInfoString); sys.stdout.flush();
+
     # Close file
+
     file.close()
+
+
+
 
 

--- a/fdtool/modules/GetFDs.py
+++ b/fdtool/modules/GetFDs.py
@@ -1,69 +1,69 @@
-import binaryRepr
-
-# Create decorator function to see how many times functions are called
-def call_counter(func):
-    
-    def helper(*args, **kwargs):
-        helper.calls += 1
-        return func(*args, **kwargs);
-    helper.calls = 0
-    helper.__name__= func.__name__
-    return helper;
-
-# Calculate Partition (C_k, r(U)) - the partitions
-#                                   of each candidate at level k are calculated
-# Takes in data frame of relation and a candidate in C_km1
-# Outputs partition of Candidate in C_km1 in relation to data frame
-
-@call_counter
-def CardOfPartition(Candidate, df):
-
-    # If length is one, find number of unique elements in column
-    if len(Candidate) == 1: return df[Candidate[0]].nunique()
-    # If length is +1, create groups over which to find number of unique elements
-    else: return df.drop_duplicates(Candidate).count()[0];
-
-# Obtain FDs(C_km1) - checks the FDs of each
-#                     candidate X in C_k
-#                   - FDs of the form X -> v_i, where
-#                     v_i *Exists* U - X^{+} are checked by 
-#                     comparing *Partition* X and *Partition* X v_i
-#
-# F = Null_Set
-# for each candidate X in C_km1 
-#   for each v_i *exists* U - X^{+}     \\Pruning rule 3
-#       if (Cardinality(*Partition* X) == Cardinality(*Partition X v_i)) then
-#       {
-#           X* = X *Union* {v_i}
-#           F = F *Union* {X -> v_i}    \\Theorem 2
-#       }
-#   return (F);
-
-def f(C_km1, df, Closure, U, Cardinality):
-
-    # Set F to null list; Initialize U_c to remaining columns in data frame
-    F = []; U_c = list(df.head(0));
-    
-    # Identify the subsets whose cardinality of partition should be tested
-    SubsetsToCheck = [list(Subset) for Subset in set([frozenset(Candidate + [v_i]) for Candidate in C_km1 for v_i in list(set(U_c).difference(Closure[binaryRepr.toBin(Candidate, U)]))])];
-    
-    # Add singleton set to SubsetsToCheck if on first k-level
-    if len(C_km1[0]) == 1: SubsetsToCheck += C_km1;
-    
-    # Iterate through subsets mapped to the Cardinality of Partition function
-    for Cand, Card in zip(SubsetsToCheck, map(CardOfPartition, SubsetsToCheck, [df]*len(SubsetsToCheck))):
-        # Add Cardinality of Partition to dictionary
-        Cardinality[binaryRepr.toBin(Cand, U)] = Card;
-
-    # Iterate through candidates of C_km1
-    for Candidate in C_km1:
-        # Iterate though attribute subsets that are not in U - X{+}; difference b/t U and inclusive closure of candidate    
-        for v_i in list(set(U_c).difference(Closure[binaryRepr.toBin(Candidate, U)])):
-            # Check if the cardinality of the partition of {Candidate} is equal to that of {Candidate, v_i}
-            if Cardinality[binaryRepr.toBin(Candidate, U)] == Cardinality[binaryRepr.toBin(Candidate + [v_i], U)]:
-                # Add attribute v_i to closure
-                Closure[binaryRepr.toBin(Candidate, U)].add(v_i)
-                # Add list (Candidate, v_i) to F
-                F.append([tuple(Candidate), v_i]);
-    
-    return Closure, F, Cardinality;
+from . import binaryRepr
+
+# Create decorator function to see how many times functions are called
+def call_counter(func):
+    
+    def helper(*args, **kwargs):
+        helper.calls += 1
+        return func(*args, **kwargs);
+    helper.calls = 0
+    helper.__name__= func.__name__
+    return helper;
+
+# Calculate Partition (C_k, r(U)) - the partitions
+#                                   of each candidate at level k are calculated
+# Takes in data frame of relation and a candidate in C_km1
+# Outputs partition of Candidate in C_km1 in relation to data frame
+
+@call_counter
+def CardOfPartition(Candidate, df):
+
+    # If length is one, find number of unique elements in column
+    if len(Candidate) == 1: return df[Candidate[0]].nunique()
+    # If length is +1, create groups over which to find number of unique elements
+    else: return df.drop_duplicates(Candidate).count()[0];
+
+# Obtain FDs(C_km1) - checks the FDs of each
+#                     candidate X in C_k
+#                   - FDs of the form X -> v_i, where
+#                     v_i *Exists* U - X^{+} are checked by 
+#                     comparing *Partition* X and *Partition* X v_i
+#
+# F = Null_Set
+# for each candidate X in C_km1 
+#   for each v_i *exists* U - X^{+}     \\Pruning rule 3
+#       if (Cardinality(*Partition* X) == Cardinality(*Partition X v_i)) then
+#       {
+#           X* = X *Union* {v_i}
+#           F = F *Union* {X -> v_i}    \\Theorem 2
+#       }
+#   return (F);
+
+def f(C_km1, df, Closure, U, Cardinality):
+
+    # Set F to null list; Initialize U_c to remaining columns in data frame
+    F = []; U_c = list(df.head(0));
+    
+    # Identify the subsets whose cardinality of partition should be tested
+    SubsetsToCheck = [list(Subset) for Subset in set([frozenset(Candidate + [v_i]) for Candidate in C_km1 for v_i in list(set(U_c).difference(Closure[binaryRepr.toBin(Candidate, U)]))])];
+    
+    # Add singleton set to SubsetsToCheck if on first k-level
+    if len(C_km1[0]) == 1: SubsetsToCheck += C_km1;
+    
+    # Iterate through subsets mapped to the Cardinality of Partition function
+    for Cand, Card in zip(SubsetsToCheck, list(map(CardOfPartition, SubsetsToCheck, [df]*len(SubsetsToCheck)))):
+        # Add Cardinality of Partition to dictionary
+        Cardinality[binaryRepr.toBin(Cand, U)] = Card;
+
+    # Iterate through candidates of C_km1
+    for Candidate in C_km1:
+        # Iterate though attribute subsets that are not in U - X{+}; difference b/t U and inclusive closure of candidate    
+        for v_i in list(set(U_c).difference(Closure[binaryRepr.toBin(Candidate, U)])):
+            # Check if the cardinality of the partition of {Candidate} is equal to that of {Candidate, v_i}
+            if Cardinality[binaryRepr.toBin(Candidate, U)] == Cardinality[binaryRepr.toBin(Candidate + [v_i], U)]:
+                # Add attribute v_i to closure
+                Closure[binaryRepr.toBin(Candidate, U)].add(v_i)
+                # Add list (Candidate, v_i) to F
+                F.append([tuple(Candidate), v_i]);
+    
+    return Closure, F, Cardinality;

--- a/fdtool/modules/ObtainEquivalences.py
+++ b/fdtool/modules/ObtainEquivalences.py
@@ -1,29 +1,29 @@
-# ObtainEquivalences(C_km1, F) - obtains equivalent candidates
-#                                from the discovered FDs.
-#
-# E = Null_Set
-# for each candidate X in C_km1
-#   for each Y -> v_i *Exists* F
-#       if (X *isContainedIn* Y^{+} and Y *isContainedIn* X^{+}) then   
-#           E = E *Union* { X <-> Y}    \\by Theorem 3
-# return (E);
-
-import binaryRepr
-
-def f(C_km1, F, Closure, U):
-
-    # Set E to null list
-    E = []
-    
-    # Iterate through candidates in C_km1
-    for X in C_km1:
-        # Iterate through functional dependences Y -> v_i in F
-        for Y in F:
-            # Check if X is contained in inclusive closure of Y and vice versa
-            if set(X).issubset(Closure[binaryRepr.toBin(list(Y[0]), U)]) and set(Y[0]).issubset(Closure[binaryRepr.toBin(X, U)]):
-                # Check that equivalence is not already in E and is not trivial
-                if [tuple(X), Y[0]] not in E and [Y[0], tuple(X)] not in E and Y[0]!=tuple(X):
-                    # Append to equivalence set
-                    E.append([tuple(X), Y[0]]);
-    return E;
-
+# ObtainEquivalences(C_km1, F) - obtains equivalent candidates
+#                                from the discovered FDs.
+#
+# E = Null_Set
+# for each candidate X in C_km1
+#   for each Y -> v_i *Exists* F
+#       if (X *isContainedIn* Y^{+} and Y *isContainedIn* X^{+}) then   
+#           E = E *Union* { X <-> Y}    \\by Theorem 3
+# return (E);
+
+from . import binaryRepr
+
+def f(C_km1, F, Closure, U):
+
+    # Set E to null list
+    E = []
+    
+    # Iterate through candidates in C_km1
+    for X in C_km1:
+        # Iterate through functional dependences Y -> v_i in F
+        for Y in F:
+            # Check if X is contained in inclusive closure of Y and vice versa
+            if set(X).issubset(Closure[binaryRepr.toBin(list(Y[0]), U)]) and set(Y[0]).issubset(Closure[binaryRepr.toBin(X, U)]):
+                # Check that equivalence is not already in E and is not trivial
+                if [tuple(X), Y[0]] not in E and [Y[0], tuple(X)] not in E and Y[0]!=tuple(X):
+                    # Append to equivalence set
+                    E.append([tuple(X), Y[0]]);
+    return E;
+

--- a/fdtool/modules/Prune.py
+++ b/fdtool/modules/Prune.py
@@ -1,75 +1,75 @@
-# Prune(C_km1, C_k, E) - exploits the four
-#                        pruning rules to reduce the size of search space
-#
-# for each S *Exists* C_k
-#   for each Y -> v_i *Exists* C_km1
-#        if (X *isContainedIn* S) then
-#        {
-#           if (X *Exists* {Z | Y <-> *Exists* E}) then
-#           {
-#               delete S from C_k;  //Pruning rule 1
-#               break;
-#           }
-#           if (X* *isContainedIn* S) then
-#           {
-#               delete S from C_k;  //Pruning rule 2
-#               break;
-#           }
-#           S* = S* *Union* X*;     //Pruning rule 3
-#           if (U == S *Union* S*) then
-#           {
-#               delete S from C_k;  //Pruning rule 4
-#               break;
-#           }
-#   }
-# return (C_k);
-
-import binaryRepr, Apriori_Gen
-
-def f(C_k, E, Closure, df, U):
-
-    # Define empty list to store sets to remove from C_k
-    SetsToRemove = []
-    
-    # Iterate through k-level candidates
-    for S in C_k:
-
-        # Iterate through all candidates at k-1-level, pruned and unpruned
-        for X in [x for x in Apriori_Gen.oneDown(C_k) if len(Closure[binaryRepr.toBin(x,U)]) > 1]:
-            
-            # Check if X is subset of S
-            if set(X).issubset(set(S)):
-
-                # Put exclusive closure of X in union with inclusive closure of S; S^{+} = S^{+} U X^{*}
-                Closure[binaryRepr.toBin(S, U)] = Closure[binaryRepr.toBin(S,U)].union(Closure[binaryRepr.toBin(X, U)].difference(set(X)))
-                
-                # Check if X is a consequent in any of the equivalences in E
-                if any(set(X) == set(E[EQ][1]) for EQ in range(len(E))):
-                    # Remove S from C_k
-                    SetsToRemove.append(S)
-                    
-                    if len(X) == 1: 
-                        try:
-                             # Drop column if in the relation
-                             df = df.drop(X, 1)
-                        except (KeyError, ValueError, TypeError) as e:
-                            # Pass if attribute does not appear in the relation
-                            pass;
-                    
-                    continue;
-                
-                # Check if S is contained in X^{+}
-                if set(S).issubset(Closure[binaryRepr.toBin(X, U)]):
-                    # Remove S from C_k
-                    SetsToRemove.append(S)
-                    continue;                
-                
-                # Check if S^{+} is equal to U
-                if set(U) == Closure[binaryRepr.toBin(S, U)]:
-                    # Remove S from C_k
-                    SetsToRemove.append(S)
-                    continue;
-
-    # Return sets in C_k that are not to be removed
-    return [Candidate for Candidate in C_k if Candidate not in SetsToRemove], Closure, df;
-
+# Prune(C_km1, C_k, E) - exploits the four
+#                        pruning rules to reduce the size of search space
+#
+# for each S *Exists* C_k
+#   for each Y -> v_i *Exists* C_km1
+#        if (X *isContainedIn* S) then
+#        {
+#           if (X *Exists* {Z | Y <-> *Exists* E}) then
+#           {
+#               delete S from C_k;  //Pruning rule 1
+#               break;
+#           }
+#           if (X* *isContainedIn* S) then
+#           {
+#               delete S from C_k;  //Pruning rule 2
+#               break;
+#           }
+#           S* = S* *Union* X*;     //Pruning rule 3
+#           if (U == S *Union* S*) then
+#           {
+#               delete S from C_k;  //Pruning rule 4
+#               break;
+#           }
+#   }
+# return (C_k);
+
+from . import binaryRepr, Apriori_Gen
+
+def f(C_k, E, Closure, df, U):
+
+    # Define empty list to store sets to remove from C_k
+    SetsToRemove = []
+    
+    # Iterate through k-level candidates
+    for S in C_k:
+
+        # Iterate through all candidates at k-1-level, pruned and unpruned
+        for X in [x for x in Apriori_Gen.oneDown(C_k) if len(Closure[binaryRepr.toBin(x,U)]) > 1]:
+            
+            # Check if X is subset of S
+            if set(X).issubset(set(S)):
+
+                # Put exclusive closure of X in union with inclusive closure of S; S^{+} = S^{+} U X^{*}
+                Closure[binaryRepr.toBin(S, U)] = Closure[binaryRepr.toBin(S,U)].union(Closure[binaryRepr.toBin(X, U)].difference(set(X)))
+                
+                # Check if X is a consequent in any of the equivalences in E
+                if any(set(X) == set(E[EQ][1]) for EQ in list(range(len(E)))):
+                    # Remove S from C_k
+                    SetsToRemove.append(S)
+                    
+                    if len(X) == 1: 
+                        try:
+                             # Drop column if in the relation
+                             df = df.drop(X, 1)
+                        except (KeyError, ValueError, TypeError) as e:
+                            # Pass if attribute does not appear in the relation
+                            pass;
+                    
+                    continue;
+                
+                # Check if S is contained in X^{+}
+                if set(S).issubset(Closure[binaryRepr.toBin(X, U)]):
+                    # Remove S from C_k
+                    SetsToRemove.append(S)
+                    continue;                
+                
+                # Check if S^{+} is equal to U
+                if set(U) == Closure[binaryRepr.toBin(S, U)]:
+                    # Remove S from C_k
+                    SetsToRemove.append(S)
+                    continue;
+
+    # Return sets in C_k that are not to be removed
+    return [Candidate for Candidate in C_k if Candidate not in SetsToRemove], Closure, df;
+

--- a/fdtool/modules/keyRun.py
+++ b/fdtool/modules/keyRun.py
@@ -1,34 +1,34 @@
-from dbschema import dbschema
-from string import ascii_lowercase
-# This function
-# takes in well-formatted FDs
-# and passes them through certain
-# dbschemacmd functions to return keys
-
-def f(U, alphaString, FD_Store):
-
-    # Change format of FDs so they can be passed through dbschema
-    FD_Str = ",".join(["".join([str(k[0]), "->", str(k[1])]) for k in FD_Store])
-
-    # Follow path given in dbschema to obtain keys with FDs
-    dbschemaNotation = (alphaString, FD_Str)
-    (attrastxt, abhastxt) = dbschemaNotation
-    (attrs,abhh) = dbschema.ScanAttrAbh(attrastxt, abhastxt)
-    abhh=dbschema.mincoverage(abhh)
-    (primattr, keys) = dbschema.keysTreeAlg(attrs, abhh, 2)
-    KeyList = map(dbschema.attr2str, keys)
-
-    # Create column_dict
-    Column_Dict = {ascii_lowercase.upper()[i]: U[i] for i in range(len(U))}
-
-    # Reformat key list
-    KeyList = [str("{" + ", ".join([Column_Dict[char] for char in KeyList[k]]) + "}") for k in range(len(KeyList))]
-
-    return KeyList;
-
-
-
-
-
-
-
+from .dbschema import dbschema
+from string import ascii_lowercase
+# This function
+# takes in well-formatted FDs
+# and passes them through certain
+# dbschemacmd functions to return keys
+
+def f(U, alphaString, FD_Store):
+
+    # Change format of FDs so they can be passed through dbschema
+    FD_Str = ",".join(["".join([str(k[0]), "->", str(k[1])]) for k in FD_Store])
+
+    # Follow path given in dbschema to obtain keys with FDs
+    dbschemaNotation = (alphaString, FD_Str)
+    (attrastxt, abhastxt) = dbschemaNotation
+    (attrs,abhh) = dbschema.ScanAttrAbh(attrastxt, abhastxt)
+    abhh=dbschema.mincoverage(abhh)
+    (primattr, keys) = dbschema.keysTreeAlg(attrs, abhh, 2)
+    KeyList = list(map(dbschema.attr2str, keys))
+
+    # Create column_dict
+    Column_Dict = {ascii_lowercase.upper()[i]: U[i] for i in list(range(len(U)))}
+
+    # Reformat key list
+    KeyList = [str("{" + ", ".join([Column_Dict[char] for char in KeyList[k]]) + "}") for k in range(len(KeyList))]
+
+    return KeyList;
+
+
+
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 version = re.search(
     '^__version__\s*=\s*"(.*)"',
-    open('fdtool/fdtool.py').read(),
+    open('fdtool/fdtool.py', encoding="utf-8").read(),
     re.M
     ).group(1)
 


### PR DESCRIPTION
I used the 2to3 python tool and some manual code inspection to make the library compatible with Python v3. 
I also added some characters to the mapping dictionary for column names so that it's not bound by the length of the english alphabet, albeit it seems impossible to process files that have that many columns (tried more than once leading up to PC freezing / running out of memory if the pagefile wasn't big enough). 
I think it would be good to also package this and update the PyPy version